### PR TITLE
feat: replace marks for boolean spell

### DIFF
--- a/logic/boolean/spell.yaml
+++ b/logic/boolean/spell.yaml
@@ -2,8 +2,8 @@ __use_yte__: true
 
 custom: |
   ?f"""function(value) {{
-    const trueLabel = '<span style="color: #1f77b4; font-weight: bold;">&#9989;</span>';
-    const falseLabel = '<span style="color: #d62728; font-weight: bold;">&#10060;</span>';
+    const trueLabel = '<span>&#9989;</span>';
+    const falseLabel = '<span>&#10060;</span>';
     if (value === "{true_value}") {{
         return trueLabel;
     }} else if (value === "{false_value}") {{

--- a/logic/boolean/spell.yaml
+++ b/logic/boolean/spell.yaml
@@ -2,8 +2,8 @@ __use_yte__: true
 
 custom: |
   ?f"""function(value) {{
-    const trueLabel = '<span style="color: #1f77b4; font-weight: bold;">+</span>';
-    const falseLabel = '<span style="color: #d62728; font-weight: bold;">-</span>';
+    const trueLabel = '<span style="color: #1f77b4; font-weight: bold;">&#9989;</span>';
+    const falseLabel = '<span style="color: #d62728; font-weight: bold;">&#10060;</span>';
     if (value === "{true_value}") {{
         return trueLabel;
     }} else if (value === "{false_value}") {{


### PR DESCRIPTION
The boolean spell currently draws a blue `+` for true values and a red `-` for false ones.
While + and - are intuitive they are not good to see in a large dataframe. Also I would stick to red and green colors.
Still, I would use emojis for boolean values as they are more readable.
In this case ❌ and ✅ are the obvious choice to me.