### PR TITLE
fix: clin-sig - reduce whitespace between badges

### DIFF
--- a/med/clin-sig/meta.yaml
+++ b/med/clin-sig/meta.yaml
@@ -1,4 +1,4 @@
-name: clin_sig
+name: clin-sig
 type: "column"
 description: |
   This spell visualizes the clinical significance, given in clinvar significance terms (https://www.ncbi.nlm.nih.gov/clinvar/)

--- a/med/clin-sig/spell.yaml
+++ b/med/clin-sig/spell.yaml
@@ -21,6 +21,6 @@ custom: |
       "pathogenic": "rgb(189 33 48)" // dark red 
     };
 
-    const splitValues = value.split(",").map(item => `<span style="display: inline-block; padding: 0.25em 0.5em; font-size: 0.875em; font-weight: bold; color: white; background-color: ${colorMapping[item.trim()]}; border-radius: 0.25em; margin-right: 0; ">${item.trim()}</span>`);
+    const splitValues = value.split(",").map(item => `<span style="display: inline-block; padding: 0.25em 0.5em; font-size: 0.875em; font-weight: bold; color: white; background-color: ${colorMapping[item.trim()]}; border-radius: 0.25em;">${item.trim()}</span>`);
     return splitValues.join(' '); 
   }

--- a/med/clin-sig/spell.yaml
+++ b/med/clin-sig/spell.yaml
@@ -21,6 +21,6 @@ custom: |
       "pathogenic": "rgb(189 33 48)" // dark red 
     };
 
-    const splitValues = value.split(",").map(item => `<span style="display: inline-block; padding: 0.25em 0.5em; font-size: 0.875em; font-weight: bold; color: white; background-color: ${colorMapping[item.trim()]}; border-radius: 0.25em; margin-right: 0.5em; ">${item.trim()}</span>`);
+    const splitValues = value.split(",").map(item => `<span style="display: inline-block; padding: 0.25em 0.5em; font-size: 0.875em; font-weight: bold; color: white; background-color: ${colorMapping[item.trim()]}; border-radius: 0.25em; margin-right: 0; ">${item.trim()}</span>`);
     return splitValues.join(' '); 
   }


### PR DESCRIPTION
Not really a fix but a minor improvement reducing the whitespace between badges.

Before:
<img width="373" alt="Screenshot 2024-11-27 at 10 35 45" src="https://github.com/user-attachments/assets/849478d5-a7d6-41a9-a063-87eebaafba2e">

After:
<img width="356" alt="Screenshot 2024-11-27 at 10 55 42" src="https://github.com/user-attachments/assets/1a20214a-6cca-4a63-bb6d-51ee3f5267bd">
