### PR TITLE
refactor: Update clin_sig spell with newly available pills plot

### DIFF
--- a/med/clin-sig/spell.yaml
+++ b/med/clin-sig/spell.yaml
@@ -20,12 +20,12 @@ plot:
       - pathogenic/likely_pathogenic
       - pathogenic
     range:
-      - "#6C757D"
-      - "#343A40"
+      - "#E4E6E7"
+      - "#73808C"
       - "#ADB5BD"
-      - "#218838"
-      - "#218838"
-      - "#28A745"
+      - "#28A443"
+      - "#28A443"
+      - "#46D267"
       - "#20C997"
       - "#FFC107"
       - "#17A2B8"

--- a/med/clin-sig/spell.yaml
+++ b/med/clin-sig/spell.yaml
@@ -1,26 +1,38 @@
 __use_yte__: true
 
-custom: |
-  function(value){
-    const colorMapping = {
-      "unknown": "rgb(108 117 125)", // gray 
-      "not_provided": "rgb(52 58 64)", // dark gray 
-      "other": "rgb(173 181 189)", // light gray 
-      "benign": "rgb(33 136 56)", // green 
-      "benign/likely_benign": "rgb(33 136 56)", // dark green 
-      "likely_benign": "rgb(40 167 69)", // green 
-      "protective": "rgb(32 201 151)", // teal 
-      "uncertain_significance": "rgb(255 193 7)", // yellow 
-      "conflicting_interpretations_of_pathogenicity": "rgb(23 162 184)", // cyan 
-      "association": "rgb(0 123 255)", // blue 
-      "affects": "rgb(111 66 193)", // purple 
-      "drug_response": "rgb(102 16 242)", // dark purple 
-      "risk_factor": "rgb(227 52 47)", // red 
-      "likely_pathogenic": "rgb(220 53 69)", // dark red 
-      "pathogenic/likely_pathogenic": "rgb(189 33 48)", // deep red 
-      "pathogenic": "rgb(189 33 48)" // dark red 
-    };
-
-    const splitValues = value.split(",").map(item => `<span style="display: inline-block; padding: 0.25em 0.5em; font-size: 0.875em; font-weight: bold; color: white; background-color: ${colorMapping[item.trim()]}; border-radius: 0.25em;">${item.trim()}</span>`);
-    return splitValues.join(' '); 
-  }
+plot:
+  pills:
+    domain:
+      - unknown
+      - not_provided
+      - other
+      - benign
+      - benign/likely_benign
+      - likely_benign
+      - protective
+      - uncertain_significance
+      - conflicting_interpretations_of_pathogenicity
+      - association
+      - affects
+      - drug_response
+      - risk_factor
+      - likely_pathogenic
+      - pathogenic/likely_pathogenic
+      - pathogenic
+    range:
+      - "#6C757D"
+      - "#343A40"
+      - "#ADB5BD"
+      - "#218838"
+      - "#218838"
+      - "#28A745"
+      - "#20C997"
+      - "#FFC107"
+      - "#17A2B8"
+      - "#007BFF"
+      - "#6F42C1"
+      - "#6610F2"
+      - "#E3342F"
+      - "#DC3545"
+      - "#BD2130"
+      - "#BD2130"


### PR DESCRIPTION
This PR updates the coin_sig spell to make use of the new `pills` keyword added in [datavzrd v2.48.0](https://github.com/datavzrd/datavzrd/compare/v2.47.1...v2.48.0).